### PR TITLE
fixed issue with wrong buffer size - uploads have no trailing garbage now

### DIFF
--- a/src/com/alexbbb/uploadservice/UploadService.java
+++ b/src/com/alexbbb/uploadservice/UploadService.java
@@ -258,11 +258,11 @@ public class UploadService extends IntentService {
 
             final InputStream stream = file.getStream();
             byte[] buffer = new byte[BUFFER_SIZE];
-            long bytesRead;
+            int bytesRead;
 
             try {
                 while ((bytesRead = stream.read(buffer, 0, buffer.length)) > 0) {
-                    requestStream.write(buffer, 0, buffer.length);
+                    requestStream.write(buffer, 0, bytesRead);
                     uploadedBytes += bytesRead;
                     broadcastProgress(uploadId, uploadedBytes, totalBytes);
                 }


### PR DESCRIPTION
if the buffer.length is used uploads end up occasionally with trailing garbage - this should fix the issue