### PR TITLE
Binary upload docs and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
-/bin
-/gen
+bin/
+gen/
 .DS_Store
 node_modules
+.gradle/
+.idea/
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties
+android-upload-service.iml
+app.iml

--- a/README.md
+++ b/README.md
@@ -158,6 +158,43 @@ public void upload(final Context context) {
 }
 ```
 
+## Binary Upload
+The binary upload uses a single file as the raw body of the upload request.
+
+``` java
+public void upload(final Context context) {
+    final BinaryUploadRequest request = new BinaryUploadRequest(context,
+                                                                "custom-upload-id",
+                                                                "http://www.yoursite.com/yourscript");
+    
+    // you can pass some data as request header, but you should be extremely careful
+    request.addHeader("file-name", paramNameString);
+    
+    request.setFileToUpload(fileToUploadPath);
+    
+    request.setNotificationConfig(R.drawable.ic_launcher, getString(R.string.app_name),
+                            getString(R.string.uploading), getString(R.string.upload_success),
+                            getString(R.string.upload_error), false);
+                            
+    // if you comment the following line, the system default user-agent will be used
+    request.setCustomUserAgent("UploadServiceDemo/1.0");
+    
+    // set the intent to perform when the user taps on the upload notification.
+    // currently tested only with intents that launches an activity
+    // if you comment this line, no action will be performed when the user taps on the notification
+    request.setNotificationClickIntent(new Intent(this, MainActivity.class));
+    
+    // set the maximum number of automatic upload retries on error
+    request.setMaxRetries(2);
+    
+    try {
+        UploadService.startUpload(request);
+    } catch (Exception exc) {
+        Toast.makeText(this, "Malformed upload request. " + exc.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
+    }
+}
+```
+
 ## How to monitor upload status
 Once the service is started, it publishes the upload status with broadcast intents.
 For the sake of simplicity and to not bother you with the writing of a broadcast receiver,

--- a/examples/app/.gitignore
+++ b/examples/app/.gitignore
@@ -1,3 +1,0 @@
-/gen
-/bin
-.DS_Store

--- a/examples/app/build.gradle
+++ b/examples/app/build.gradle
@@ -13,7 +13,11 @@ buildscript {
 apply plugin: 'com.android.application'
 
 dependencies {
+    // NOTE: This is dependency on the official release, use this for reference in your projects.
     compile 'com.github.alexbbb:android-upload-service:1.3.1'
+    
+    // NOTE: The android-upload-service project added as a dependency for development purposes.
+    // compile project(':android-upload-service')
 }
 
 android {

--- a/examples/app/res/layout/activity_main.xml
+++ b/examples/app/res/layout/activity_main.xml
@@ -68,12 +68,19 @@
         android:ems="10" />
     
     <Button
-        android:id="@+id/uploadButton"
+        android:id="@+id/multipartUploadButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:text="@string/upload" />
-    
+        android:text="@string/multipart_upload" />
+
+    <Button
+        android:id="@+id/binaryUploadButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/binary_upload" />
+
     <Button
         android:id="@+id/cancelUploadButton"
         android:layout_width="wrap_content"

--- a/examples/app/res/values/strings.xml
+++ b/examples/app/res/values/strings.xml
@@ -2,7 +2,8 @@
 <resources>
 
     <string name="app_name">Upload Service</string>
-    <string name="upload">Upload</string>
+    <string name="multipart_upload">Multipart Upload</string>
+    <string name="binary_upload">Binary Upload</string>
     <string name="cancel_upload">Cancel upload</string>
     <string name="server_script_url">Server script URL</string>
     <string name="file_to_upload_path">Path of the file to upload</string>

--- a/examples/app/settings.gradle
+++ b/examples/app/settings.gradle
@@ -1,0 +1,2 @@
+include ':android-upload-service'
+project(':android-upload-service').projectDir = new File(settingsDir, '../../')

--- a/examples/server-nodejs/index.js
+++ b/examples/server-nodejs/index.js
@@ -1,5 +1,8 @@
 var express = require('express');
 var multer = require('multer');
+var fs = require('fs');
+var path = require('path');
+
 var app = express();
 
 var UPLOAD_PATH = "./uploads/";
@@ -12,10 +15,10 @@ var multerFiles = multer({ dest: UPLOAD_PATH,
         return filename;
     },
     onFileUploadStart: function (file) {
-        console.log("Started upload of: " + file.originalname);
+        console.log("Started multipart upload of: " + file.originalname);
     },
     onFileUploadComplete: function (file) {
-        console.log("Finished upload of: " + file.fieldname + " to: " + file.path);
+        console.log("Finished multipart upload of: " + file.fieldname + " to: " + file.path);
         fileUploadCompleted = true;
     }
 });
@@ -24,13 +27,26 @@ app.get('/', function(req, res) {
     res.end("Android Upload Service Demo node.js server running!");
 });
 
-// handle uploads
-app.post('/upload', multerFiles, function(req, res) {
-    if(fileUploadCompleted){
+// handle multipart uploads
+app.post('/upload/multipart', multerFiles, function(req, res) {
+    if (fileUploadCompleted) {
         fileUploadCompleted = false;
         res.header('transfer-encoding', ''); // disable chunked transfer encoding
         res.end("Upload Ok!");
     }
+});
+
+// handle binary uploads
+app.post('/upload/binary', function(req, res) {
+    var filename = req.headers["file-name"];
+    console.log("Started binary upload of: " + filename);
+    var filepath = path.resolve(UPLOAD_PATH, filename);
+    var out = fs.createWriteStream(filepath, { flags: 'w', encoding: null, fd: null, mode: 666 });
+    req.pipe(out);
+    req.on('end', function() {
+        console.log("Finished multipart upload of: " + filename + " to: " + filepath);
+        res.sendStatus(200);
+    });
 });
 
 var server = app.listen(SERVER_PORT, function() {

--- a/src/com/alexbbb/uploadservice/UploadNotificationConfig.java
+++ b/src/com/alexbbb/uploadservice/UploadNotificationConfig.java
@@ -20,7 +20,7 @@ class UploadNotificationConfig implements Parcelable {
     private final String completed;
     private final String error;
     private final boolean autoClearOnSuccess;
-    private final boolean ringTone;
+    private boolean ringTone;
     private Intent clickIntent;
 
     public UploadNotificationConfig() {


### PR DESCRIPTION
Add nodejs example for binary upload handling. Add a block in the README.md with the binary upload code. Add commented project dependency in the grade app for easier development.

As a side note, feel free to edit the readme and the example before merge. It may be better for the example app to support only the multipart upload and have the binary upload method in it just for convenience.

Closes #50.