### PR TITLE
Multiupload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and now you're ready to rock!
 
 <em>I strongly encourage you to build and run the demo app that you can find in the [examples](#examples), together with one of the provided server implementations and to check [JavaDocs](http://alexbbb.github.io/android-upload-service/javadoc/).</em>
 
-### HTTP Multipart Upload
+### [HTTP Multipart Upload](http://alexbbb.github.io/android-upload-service/javadoc/com/alexbbb/uploadservice/MultipartUploadRequest.html)
 This is the most common way to upload files on a server. It's the same kind of request that browsers do when you use the `<form>` tag with one or more files. Here's a minimal example:
 
 ```java
@@ -73,7 +73,7 @@ public void uploadMultipart(final Context context) {
 }
 ```
 
-### Binary Upload
+### [Binary Upload](http://alexbbb.github.io/android-upload-service/javadoc/com/alexbbb/uploadservice/BinaryUploadRequest.html)
 The binary upload uses a single file as the raw body of the upload request.
 
 ``` java
@@ -96,7 +96,7 @@ public void uploadBinary(final Context context) {
 ```
 
 ### Monitoring upload status
-To listen for the status of the upload service, use the provided `UploadServiceBroadcastReceiver`. Override its methods to add your own business logic. Example on how to use it in an activity:
+To listen for the status of the upload service, use the provided [UploadServiceBroadcastReceiver](http://alexbbb.github.io/android-upload-service/javadoc/com/alexbbb/uploadservice/UploadServiceBroadcastReceiver.html). Override its methods to add your own business logic. Example on how to use it in an activity:
 
 ```java
 public class YourActivity extends Activity {
@@ -227,7 +227,7 @@ Let's face it, doing network programming is not easy as there are many things th
 * Check [JavaDocs](http://alexbbb.github.io/android-upload-service/javadoc/) for full class and methods docs
 * Is the server URL correct?
 * Is the server URL reachable from your device? Check if there are firewalls or other kind of restrictions between your device and the server.
-* Are you sure that the server side is working properly?
+* Are you sure that the server side is working properly? For example, if you use PHP in your server side, and you get an EPIPE exception, check if the content size you are trying to upload exceeds the values of `upload_max_filesize` or `post_max_size` set in your `php.ini`
 * Have you properly set up the request with all the headers, parameters and files that the server expects?
 * Have you tried to make an upload using the demo app and one of the provided server implementations? I use the node.js version which provides good feedback and supports both HTTP Multipart and binary uploads.
 

--- a/examples/app/.idea/gradle.xml
+++ b/examples/app/.idea/gradle.xml
@@ -10,6 +10,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/../../uploadservice" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/examples/app/app/build.gradle
+++ b/examples/app/app/build.gradle
@@ -24,5 +24,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.nononsenseapps:filepicker:2.4.2'
-    compile 'com.alexbbb:uploadservice:1.6'
+    //compile 'com.alexbbb:uploadservice:1.6'
+    //comment the previous line and uncomment the next line for development (it uses the local lib)
+    compile project(':uploadservice')
 }

--- a/examples/app/app/src/main/java/com/alexbbb/uploadservicedemo/MainActivity.java
+++ b/examples/app/app/src/main/java/com/alexbbb/uploadservicedemo/MainActivity.java
@@ -1,15 +1,21 @@
 package com.alexbbb.uploadservicedemo;
 
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.alexbbb.uploadservice.BinaryUploadRequest;
@@ -24,6 +30,10 @@ import com.nononsenseapps.filepicker.FilePickerActivity;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import butterknife.Bind;
@@ -42,39 +52,52 @@ public class MainActivity extends AppCompatActivity {
     private static final String USER_AGENT = "UploadServiceDemo/" + BuildConfig.VERSION_NAME;
     private static final int FILE_CODE = 1;
 
-    @Bind(R.id.uploadProgress) ProgressBar progressBar;
+    @Bind(R.id.container) ViewGroup container;
     @Bind(R.id.multipartUploadButton) Button multipartUploadButton;
     @Bind(R.id.binaryUploadButton) Button binaryUploadButton;
-    @Bind(R.id.cancelUploadButton) Button cancelUploadButton;
+    @Bind(R.id.cancelAllUploadsButton) Button cancelAllUploadsButton;
     @Bind(R.id.serverURL) EditText serverUrl;
-    @Bind(R.id.fileToUpload) EditText fileToUpload;
+    @Bind(R.id.filesToUpload) EditText filesToUpload;
     @Bind(R.id.parameterName) EditText parameterName;
     @Bind(R.id.displayNotification) CheckBox displayNotification;
+
+    private Map<String, UploadProgressViewHolder> uploadProgressHolders = new HashMap<>();
 
     private final UploadServiceBroadcastReceiver uploadReceiver =
             new UploadServiceBroadcastReceiver() {
 
         @Override
         public void onProgress(String uploadId, int progress) {
-            progressBar.setProgress(progress);
-
             Log.i(TAG, "The progress of the upload with ID " + uploadId + " is: " + progress);
+
+            if (uploadProgressHolders.get(uploadId) == null)
+                return;
+
+            uploadProgressHolders.get(uploadId).progressBar.setProgress(progress);
         }
 
         @Override
         public void onError(String uploadId, Exception exception) {
-            progressBar.setProgress(0);
-
             Log.e(TAG, "Error in upload with ID: " + uploadId + ". "
                         + exception.getLocalizedMessage(), exception);
+
+            if (uploadProgressHolders.get(uploadId) == null)
+                return;
+
+            container.removeView(uploadProgressHolders.get(uploadId).itemView);
+            uploadProgressHolders.remove(uploadId);
         }
 
         @Override
         public void onCompleted(String uploadId, int serverResponseCode, String serverResponseMessage) {
-            progressBar.setProgress(0);
-
             Log.i(TAG, "Upload with ID " + uploadId + " is completed: " + serverResponseCode + ", "
                        + serverResponseMessage);
+
+            if (uploadProgressHolders.get(uploadId) == null)
+                return;
+
+            container.removeView(uploadProgressHolders.get(uploadId).itemView);
+            uploadProgressHolders.remove(uploadId);
         }
     };
 
@@ -83,9 +106,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
-
-        progressBar.setMax(100);
-        progressBar.setProgress(0);
 
         // Uncomment this line to enable self-signed SSL certificates in HTTPS connections
         // WARNING: Do not use in production environment. Recommended for development only
@@ -108,12 +128,12 @@ public class MainActivity extends AppCompatActivity {
         Toast.makeText(this, message, Toast.LENGTH_LONG).show();
     }
 
-    private UploadNotificationConfig getNotificationConfig() {
+    private UploadNotificationConfig getNotificationConfig(String filename) {
         if (!displayNotification.isChecked()) return null;
 
         return new UploadNotificationConfig()
             .setIcon(R.drawable.ic_upload)
-            .setTitle(getString(R.string.app_name))
+            .setTitle(filename)
             .setInProgressMessage(getString(R.string.uploading))
             .setCompletedMessage(getString(R.string.upload_success))
             .setErrorMessage(getString(R.string.upload_error))
@@ -126,56 +146,80 @@ public class MainActivity extends AppCompatActivity {
     @OnClick(R.id.multipartUploadButton)
     void onMultipartUploadClick() {
         final String serverUrlString = serverUrl.getText().toString();
-        final String fileToUploadPath = fileToUpload.getText().toString();
         final String paramNameString = parameterName.getText().toString();
-        final String uploadID = UUID.randomUUID().toString();
 
-        try {
-            new MultipartUploadRequest(this, uploadID, serverUrlString)
-                .addFileToUpload(fileToUploadPath, paramNameString)
-                .setNotificationConfig(getNotificationConfig())
-                .setCustomUserAgent(USER_AGENT)
-                .setMaxRetries(2)
-                .startUpload();
+        final String filesToUploadString = filesToUpload.getText().toString();
+        final String[] filesToUploadArray = filesToUploadString.split(",");
 
-        // these are the different exceptions that may be thrown
-        } catch (FileNotFoundException exc) {
-            showToast(exc.getMessage());
-        } catch (IllegalArgumentException exc) {
-            showToast("Missing some arguments. " + exc.getMessage());
-        } catch (MalformedURLException exc) {
-            showToast(exc.getMessage());
+        for (String fileToUploadPath : filesToUploadArray) {
+            try {
+                final String uploadID = UUID.randomUUID().toString();
+                final String filename = getFilename(fileToUploadPath);
+
+                new MultipartUploadRequest(this, uploadID, serverUrlString)
+                        .addFileToUpload(fileToUploadPath, paramNameString)
+                        .setNotificationConfig(getNotificationConfig(filename))
+                        .setCustomUserAgent(USER_AGENT)
+                        .setMaxRetries(2)
+                        .startUpload();
+
+                View uploadProgressView = getLayoutInflater().inflate(R.layout.view_upload_progress, null);
+                UploadProgressViewHolder viewHolder = new UploadProgressViewHolder(uploadProgressView, filename);
+                viewHolder.uploadId = uploadID;
+                container.addView(viewHolder.itemView, 0);
+                uploadProgressHolders.put(uploadID, viewHolder);
+
+                // these are the different exceptions that may be thrown
+            } catch (FileNotFoundException exc) {
+                showToast(exc.getMessage());
+            } catch (IllegalArgumentException exc) {
+                showToast("Missing some arguments. " + exc.getMessage());
+            } catch (MalformedURLException exc) {
+                showToast(exc.getMessage());
+            }
         }
     }
 
     @OnClick(R.id.binaryUploadButton)
     void onUploadBinaryClick() {
         final String serverUrlString = serverUrl.getText().toString();
-        final String fileToUploadPath = fileToUpload.getText().toString();
-        final String uploadID = UUID.randomUUID().toString();
 
-        try {
-            new BinaryUploadRequest(this, uploadID, serverUrlString)
-                .addHeader("file-name", new File(fileToUploadPath).getName())
-                .setFileToUpload(fileToUploadPath)
-                .setNotificationConfig(getNotificationConfig())
-                .setCustomUserAgent(USER_AGENT)
-                .setMaxRetries(2)
-                .startUpload();
+        final String filesToUploadString = filesToUpload.getText().toString();
+        final String[] filesToUploadArray = filesToUploadString.split(",");
 
-        // these are the different exceptions that may be thrown
-        } catch (FileNotFoundException exc) {
-            showToast(exc.getMessage());
-        } catch (IllegalArgumentException exc) {
-            showToast("Missing some arguments. " + exc.getMessage());
-        } catch (MalformedURLException exc) {
-            showToast(exc.getMessage());
+        for (String fileToUploadPath : filesToUploadArray) {
+            try {
+                final String uploadID = UUID.randomUUID().toString();
+                final String filename = getFilename(fileToUploadPath);
+
+                new BinaryUploadRequest(this, uploadID, serverUrlString)
+                        .addHeader("file-name", new File(fileToUploadPath).getName())
+                        .setFileToUpload(fileToUploadPath)
+                        .setNotificationConfig(getNotificationConfig(filename))
+                        .setCustomUserAgent(USER_AGENT)
+                        .setMaxRetries(2)
+                        .startUpload();
+
+                View uploadProgressView = getLayoutInflater().inflate(R.layout.view_upload_progress, null);
+                UploadProgressViewHolder viewHolder = new UploadProgressViewHolder(uploadProgressView, filename);
+                viewHolder.uploadId = uploadID;
+                container.addView(viewHolder.itemView, 0);
+                uploadProgressHolders.put(uploadID, viewHolder);
+
+                // these are the different exceptions that may be thrown
+            } catch (FileNotFoundException exc) {
+                showToast(exc.getMessage());
+            } catch (IllegalArgumentException exc) {
+                showToast("Missing some arguments. " + exc.getMessage());
+            } catch (MalformedURLException exc) {
+                showToast(exc.getMessage());
+            }
         }
     }
 
-    @OnClick(R.id.cancelUploadButton)
-    void onCancelUploadButtonClick() {
-        UploadService.stopCurrentUpload();
+    @OnClick(R.id.cancelAllUploadsButton)
+    void onCancelAllUploadsButtonClick() {
+        UploadService.stopAllUploads();
     }
 
     @OnClick(R.id.pickFile)
@@ -183,7 +227,7 @@ public class MainActivity extends AppCompatActivity {
         // Starts NoNonsense-FilePicker (https://github.com/spacecowboy/NoNonsense-FilePicker)
         Intent intent = new Intent(this, FilePickerActivity.class);
 
-        intent.putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false);
+        intent.putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, true);
         intent.putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, false);
         intent.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_FILE);
 
@@ -200,8 +244,77 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == FILE_CODE && resultCode == Activity.RESULT_OK) {
-            String absolutePath = new File(data.getData().getPath()).getAbsolutePath();
-            fileToUpload.setText(absolutePath);
+            List<Uri> resultUris = new ArrayList<>();
+
+            if (data.getBooleanExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)) {
+                // For JellyBean and above
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    ClipData clip = data.getClipData();
+
+                    if (clip != null) {
+                        for (int i = 0; i < clip.getItemCount(); i++) {
+                            resultUris.add(clip.getItemAt(i).getUri());
+                        }
+                    }
+                    // For Ice Cream Sandwich
+                } else {
+                    ArrayList<String> paths = data.getStringArrayListExtra(FilePickerActivity.EXTRA_PATHS);
+
+                    if (paths != null) {
+                        for (String path: paths) {
+                            resultUris.add(Uri.parse(path));
+                        }
+                    }
+                }
+            } else {
+                resultUris.add(data.getData());
+            }
+
+            StringBuilder absolutePathsConcat = new StringBuilder();
+            for (Uri uri : resultUris) {
+                if (absolutePathsConcat.length() == 0) {
+                    absolutePathsConcat.append(new File(uri.getPath()).getAbsolutePath());
+                } else {
+                    absolutePathsConcat.append(",").append(new File(uri.getPath()).getAbsolutePath());
+                }
+            }
+            filesToUpload.setText(absolutePathsConcat.toString());
+        }
+    }
+
+    private String getFilename(String filepath) {
+        if (filepath == null)
+            return null;
+
+        final String[] filepathParts = filepath.split("/");
+
+        return filepathParts[filepathParts.length - 1];
+    }
+
+    class UploadProgressViewHolder {
+        View itemView;
+
+        @Bind(R.id.uploadTitle) TextView uploadTitle;
+        @Bind(R.id.uploadProgress) ProgressBar progressBar;
+
+        String uploadId;
+
+        UploadProgressViewHolder(View view, String filename) {
+            itemView = view;
+            ButterKnife.bind(this, itemView);
+
+            progressBar.setMax(100);
+            progressBar.setProgress(0);
+
+            uploadTitle.setText(getString(R.string.upload_progress, filename));
+        }
+
+        @OnClick(R.id.cancelUploadButton)
+        void onCancelUploadClick() {
+            if (uploadId == null)
+                return;
+
+            UploadService.stopUpload(uploadId);
         }
     }
 }

--- a/examples/app/app/src/main/java/com/alexbbb/uploadservicedemo/MainActivity.java
+++ b/examples/app/app/src/main/java/com/alexbbb/uploadservicedemo/MainActivity.java
@@ -99,6 +99,17 @@ public class MainActivity extends AppCompatActivity {
             container.removeView(uploadProgressHolders.get(uploadId).itemView);
             uploadProgressHolders.remove(uploadId);
         }
+
+        @Override
+        public void onCancelled(String uploadId) {
+            Log.i(TAG, "Upload with ID " + uploadId + " is cancelled");
+
+            if (uploadProgressHolders.get(uploadId) == null)
+                return;
+
+            container.removeView(uploadProgressHolders.get(uploadId).itemView);
+            uploadProgressHolders.remove(uploadId);
+        }
     };
 
     @Override

--- a/examples/app/app/src/main/res/layout/activity_main.xml
+++ b/examples/app/app/src/main/res/layout/activity_main.xml
@@ -23,7 +23,6 @@
         <EditText
             android:id="@+id/serverURL"
             android:inputType="textUri"
-            android:text="http://posttestserver.com/post.php?dump&amp;dir=mabdurrahman"
             android:hint="@string/server_url_hint"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/examples/app/app/src/main/res/layout/activity_main.xml
+++ b/examples/app/app/src/main/res/layout/activity_main.xml
@@ -1,114 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:layout_margin="8sp"
-    tools:context="com.alexbbb.uploadservice.demo.MainActivity" >
-
-    <TextView
-        android:id="@+id/textView3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/upload_progress" />
-
-    <ProgressBar
-        android:id="@+id/uploadProgress"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <TextView
-        android:id="@+id/textView1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="10sp"
-        android:text="@string/server_script_url" />
-
-    <EditText
-        android:id="@+id/serverURL"
-        android:inputType="textUri"
-        android:hint="@string/server_url_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:ems="10" >
-
-        <requestFocus />
-    </EditText>
-
-    <TextView
-        android:id="@+id/textView4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="10sp"
-        android:text="@string/file_to_upload_path" />
+    android:fillViewport="true"
+    tools:context="com.alexbbb.uploadservice.demo.MainActivity">
 
     <LinearLayout
-        android:orientation="horizontal"
+        android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="8sp">
+
+        <TextView
+            android:id="@+id/textView1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="10sp"
+            android:text="@string/server_script_url" />
 
         <EditText
-            android:id="@+id/fileToUpload"
+            android:id="@+id/serverURL"
             android:inputType="textUri"
-            android:hint="@string/file_path_hint"
+            android:text="http://posttestserver.com/post.php?dump&amp;dir=mabdurrahman"
+            android:hint="@string/server_url_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ems="10" >
+
+            <requestFocus />
+        </EditText>
+
+        <TextView
+            android:id="@+id/textView4"
             android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="10sp"
+            android:text="@string/files_to_upload_path" />
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <EditText
+                android:id="@+id/filesToUpload"
+                android:inputType="textUri"
+                android:hint="@string/file_path_hint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="10" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/browse"
+                android:id="@+id/pickFile" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="10sp"
+            android:text="@string/parameter_name" />
+
+        <EditText
+            android:id="@+id/parameterName"
+            android:inputType="textUri"
+            android:hint="@string/parameter_name_hint"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ems="10" />
 
-        <Button
+        <CheckBox
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/browse"
-            android:id="@+id/pickFile" />
+            android:text="@string/display_notification"
+            android:id="@+id/displayNotification"
+            android:layout_gravity="center_horizontal"
+            android:checked="true" />
+
+        <Button
+            android:id="@+id/multipartUploadButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/multipart_upload" />
+
+        <Button
+            android:id="@+id/binaryUploadButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/binary_upload" />
+
+        <Button
+            android:id="@+id/cancelAllUploadsButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/cancel_all_uploads" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/textView5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="10sp"
-        android:text="@string/parameter_name" />
-
-    <EditText
-        android:id="@+id/parameterName"
-        android:inputType="textUri"
-        android:hint="@string/parameter_name_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:ems="10" />
-
-    <CheckBox
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/display_notification"
-        android:id="@+id/displayNotification"
-        android:layout_gravity="center_horizontal"
-        android:checked="true" />
-
-    <Button
-        android:id="@+id/multipartUploadButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/multipart_upload" />
-
-    <Button
-        android:id="@+id/binaryUploadButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/binary_upload" />
-
-    <Button
-        android:id="@+id/cancelUploadButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/cancel_upload" />
-
-</LinearLayout>
+</ScrollView>
 

--- a/examples/app/app/src/main/res/layout/view_upload_progress.xml
+++ b/examples/app/app/src/main/res/layout/view_upload_progress.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/container_head"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/uploadTitle"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="@string/upload_progress" />
+
+        <Button
+            android:id="@+id/cancelUploadButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel_upload" />
+
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/uploadProgress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/container_head" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_below="@+id/uploadProgress"
+        android:background="@color/colorPrimary" />
+
+</RelativeLayout>

--- a/examples/app/app/src/main/res/values/strings.xml
+++ b/examples/app/app/src/main/res/values/strings.xml
@@ -5,13 +5,14 @@
     <string name="multipart_upload">Multipart Upload</string>
     <string name="binary_upload">Binary Upload</string>
     <string name="cancel_upload">Cancel upload</string>
+    <string name="cancel_all_uploads">Cancel all uploads</string>
     <string name="server_script_url">Server script URL</string>
     <string name="browse">Browse..</string>
     <string name="select_file">Select file to upload</string>
-    <string name="file_to_upload_path">Path of the file to upload</string>
+    <string name="files_to_upload_path">Path of the files to upload</string>
     <string name="parameter_name">File parameter name</string>
     <string name="parameter_name_hint">E.g. uploaded_file</string>
-    <string name="upload_progress">Upload progress</string>
+    <string name="upload_progress">Upload progress: %s</string>
     <string name="uploading">Uploading</string>
     <string name="upload_success">Upload completed successfully</string>
     <string name="upload_error">Error while uploading</string>

--- a/examples/app/build.gradle
+++ b/examples/app/build.gradle
@@ -8,6 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/app/settings.gradle
+++ b/examples/app/settings.gradle
@@ -1,1 +1,3 @@
 include ':app'
+include ':uploadservice'
+project(':uploadservice').projectDir = file('../../uploadservice')

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/BinaryUploadRequest.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/BinaryUploadRequest.java
@@ -13,6 +13,11 @@ import java.net.MalformedURLException;
  */
 public class BinaryUploadRequest extends HttpUploadRequest {
 
+    /**
+     * Static constant used to identify the task type. It must be unique between task types.
+     */
+    public static final String NAME = "binary";
+
     private BinaryUploadFile file = null;
 
     /**
@@ -51,7 +56,7 @@ public class BinaryUploadRequest extends HttpUploadRequest {
     @Override
     protected void initializeIntent(Intent intent) {
         super.initializeIntent(intent);
-        intent.putExtra(UploadService.PARAM_TYPE, UploadService.UPLOAD_BINARY);
+        intent.putExtra(UploadService.PARAM_TYPE, NAME);
         intent.putExtra(UploadService.PARAM_FILE, getFile());
     }
 

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
  *
  * @author cankov
  */
-abstract class HttpUploadTask {
+abstract class HttpUploadTask implements Runnable {
 
     private static final int BUFFER_SIZE = 4096;
 
@@ -32,6 +32,10 @@ abstract class HttpUploadTask {
     protected final String customUserAgent;
     protected final int maxRetries;
     protected final ArrayList<NameValue> headers;
+
+    private int notificationId;
+    private UploadNotificationConfig notificationConfig;
+    private long lastProgressNotificationTime;
 
     protected HttpURLConnection connection = null;
     protected OutputStream requestStream = null;
@@ -53,6 +57,31 @@ abstract class HttpUploadTask {
         this.headers = intent.getParcelableArrayListExtra(UploadService.PARAM_REQUEST_HEADERS);
     }
 
+    public int getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(int notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public UploadNotificationConfig getNotificationConfig() {
+        return notificationConfig;
+    }
+
+    public void setNotificationConfig(UploadNotificationConfig notificationConfig) {
+        this.notificationConfig = notificationConfig;
+    }
+
+    public long getLastProgressNotificationTime() {
+        return lastProgressNotificationTime;
+    }
+
+    public void setLastProgressNotificationTime(long lastProgressNotificationTime) {
+        this.lastProgressNotificationTime = lastProgressNotificationTime;
+    }
+
+    @Override
     public void run() {
         int attempts = 0;
 

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
@@ -95,7 +95,9 @@ abstract class HttpUploadTask implements Runnable {
 
                 break;
             } catch (Exception exc) {
-                if (attempts > maxRetries || !shouldContinue) {
+                if (!shouldContinue) {
+                    broadcastCancelled();
+                } else if (attempts > maxRetries) {
                     broadcastError(exc);
                 } else {
                     Log.w(getClass().getName(), "Error in uploadId " + uploadId + " on attempt " + attempts
@@ -113,7 +115,15 @@ abstract class HttpUploadTask implements Runnable {
     }
 
     public void cancel() {
+        cancel(true);
+    }
+
+    public void cancel(boolean immediate) {
         this.shouldContinue = false;
+
+        if (immediate) {
+            broadcastCancelled();
+        }
     }
 
     protected void broadcastProgress(long uploadedBytes, long totalBytes) {
@@ -126,6 +136,10 @@ abstract class HttpUploadTask implements Runnable {
 
     private void broadcastCompleted(final int responseCode, final String responseMessage) {
         this.service.broadcastCompleted(uploadId, responseCode, responseMessage);
+    }
+
+    private void broadcastCancelled() {
+        this.service.broadcastCancelled(uploadId);
     }
 
     @SuppressLint("NewApi")

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
@@ -330,6 +330,8 @@ abstract class HttpUploadTask implements Runnable {
         service.sendBroadcast(intent);
 
         updateNotificationError();
+
+        service.taskCompleted(uploadId);
     }
 
     private void createNotification() {

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/HttpUploadTask.java
@@ -87,7 +87,7 @@ abstract class HttpUploadTask implements Runnable {
                 break;
             } catch (Exception exc) {
                 if (!shouldContinue) {
-                    broadcastCancelled();
+                    break;
                 } else if (attempts > maxRetries) {
                     broadcastError(exc);
                 } else {
@@ -102,6 +102,10 @@ abstract class HttpUploadTask implements Runnable {
                     }
                 }
             }
+        }
+
+        if (!shouldContinue) {
+            broadcastCancelled();
         }
     }
 

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/MultipartUploadRequest.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/MultipartUploadRequest.java
@@ -17,6 +17,11 @@ import java.util.List;
  */
 public class MultipartUploadRequest extends HttpUploadRequest {
 
+    /**
+     * Static constant used to identify the task type. It must be unique between task types.
+     */
+    public static final String NAME = "multipart";
+
     private final ArrayList<MultipartUploadFile> filesToUpload;
     private final ArrayList<NameValue> parameters;
 
@@ -58,7 +63,7 @@ public class MultipartUploadRequest extends HttpUploadRequest {
     @Override
     protected void initializeIntent(Intent intent) {
         super.initializeIntent(intent);
-        intent.putExtra(UploadService.PARAM_TYPE, UploadService.UPLOAD_MULTIPART);
+        intent.putExtra(UploadService.PARAM_TYPE, NAME);
         intent.putParcelableArrayListExtra(UploadService.PARAM_FILES, getFilesToUpload());
         intent.putParcelableArrayListExtra(UploadService.PARAM_REQUEST_PARAMETERS, getParameters());
     }

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadService.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadService.java
@@ -1,12 +1,19 @@
 package com.alexbbb.uploadservice;
 
-import android.app.IntentService;
 import android.app.NotificationManager;
+import android.app.Service;
 import android.content.Intent;
 import android.media.RingtoneManager;
+import android.os.IBinder;
 import android.os.PowerManager;
 import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationCompat.Builder;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Service to upload files in background using HTTP POST with notification center progress
@@ -16,15 +23,14 @@ import android.support.v4.app.NotificationCompat.Builder;
  * @author eliasnaur
  * @author cankov
  */
-public class UploadService extends IntentService {
+public class UploadService extends Service {
 
-    private static final String SERVICE_NAME = UploadService.class.getName();
-    private static final String TAG = "UploadService";
+    private static final String TAG = UploadService.class.getSimpleName();
 
-    private static final int UPLOAD_NOTIFICATION_ID = 1234; // Something unique
-    private static final int UPLOAD_NOTIFICATION_ID_DONE = 1235; // Something unique
+    private static final int UPLOAD_NOTIFICATION_BASE_ID = 1234; // Something unique
 
     public static String NAMESPACE = "com.alexbbb";
+    public static int UPLOAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
 
     private static final String ACTION_UPLOAD_SUFFIX = ".uploadservice.action.upload";
     protected static final String PARAM_NOTIFICATION_CONFIG = "notificationConfig";
@@ -63,13 +69,22 @@ public class UploadService extends IntentService {
     public static final String SERVER_RESPONSE_CODE = "serverResponseCode";
     public static final String SERVER_RESPONSE_MESSAGE = "serverResponseMessage";
 
-    private NotificationManager notificationManager;
-    private Builder notification;
-    private PowerManager.WakeLock wakeLock;
-    private UploadNotificationConfig notificationConfig;
-    private long lastProgressNotificationTime;
+    private static final String FOREGROUND_ACTION_SUFFIX = ".uploadservice.foreground";
 
-    private static HttpUploadTask currentTask;
+    private int notificationIncremental = 1;
+    private NotificationManager notificationManager;
+    private PowerManager.WakeLock wakeLock;
+
+    private boolean takeoverForegroundNotification;
+    private NotificationCompat.Builder tempNotificationToDisplay;
+
+    private static final int KEEP_ALIVE_TIME = 1;
+
+    private static final Map<String, HttpUploadTask> uploadTasksMap = new ConcurrentHashMap<>();
+
+    // A queue of Runnable(s)
+    private static final BlockingQueue<Runnable> uploadTasksQueue = new LinkedBlockingQueue<>();
+    private static ThreadPoolExecutor uploadThreadPool;
 
     protected static String getActionUpload() {
         return NAMESPACE + ACTION_UPLOAD_SUFFIX;
@@ -79,17 +94,38 @@ public class UploadService extends IntentService {
         return NAMESPACE + BROADCAST_ACTION_SUFFIX;
     }
 
+    protected static String getActionForeground() {
+        return NAMESPACE + FOREGROUND_ACTION_SUFFIX;
+    }
+
     /**
-     * Stops the currently active upload task.
+     * Stops the upload task with the given uploadId.
+     * @param uploadId The unique upload id
+     * @return {@code true} if an upload task was actually stopped, Otherwise {@code false}.
      */
-    public static void stopCurrentUpload() {
-        if (currentTask != null) {
-            currentTask.cancel();
+    public synchronized static boolean stopUpload(final String uploadId) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return false;
+
+        uploadTask.cancel();
+        return true;
+    }
+
+    /**
+     * Stops all upload tasks.
+     * @return {@code true} if at least one upload task was actually stopped, Otherwise {@code false}.
+     */
+    public synchronized static boolean stopAllUploads() {
+        boolean result = false;
+        for (HttpUploadTask uploadTask : uploadTasksMap.values()) {
+            uploadTask.cancel();
+            result = true;
         }
+        return result;
     }
 
     public UploadService() {
-        super(SERVICE_NAME);
+        super();
     }
 
     @Override
@@ -97,48 +133,79 @@ public class UploadService extends IntentService {
         super.onCreate();
 
         notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        notification = new NotificationCompat.Builder(this);
         PowerManager pm = (PowerManager) getSystemService(POWER_SERVICE);
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
+
+        if (UPLOAD_POOL_SIZE <= 0) {
+            UPLOAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
+        }
+        // Creates a thread pool manager
+        uploadThreadPool = new ThreadPoolExecutor(
+                UPLOAD_POOL_SIZE,       // Initial pool size
+                UPLOAD_POOL_SIZE,       // Max pool size
+                KEEP_ALIVE_TIME,
+                TimeUnit.SECONDS,
+                uploadTasksQueue);
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public synchronized int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null) {
             final String action = intent.getAction();
 
             if (getActionUpload().equals(action)) {
-                notificationConfig = intent.getParcelableExtra(PARAM_NOTIFICATION_CONFIG);
+                UploadNotificationConfig notificationConfig = intent.getParcelableExtra(PARAM_NOTIFICATION_CONFIG);
+
+                HttpUploadTask newTask = null;
 
                 String type = intent.getStringExtra(PARAM_TYPE);
                 if (UPLOAD_MULTIPART.equals(type)) {
-                    currentTask = new MultipartUploadTask(this, intent);
+                    newTask = new MultipartUploadTask(this, intent);
                 } else if (UPLOAD_BINARY.equals(type)) {
-                    currentTask = new BinaryUploadTask(this, intent);
-                } else {
-                    return;
+                    newTask = new BinaryUploadTask(this, intent);
                 }
 
-                lastProgressNotificationTime = 0;
-                wakeLock.acquire();
+                if (newTask != null) {
+                    if (shouldTakeoverForegroundNotification() || getRemainingTasks() == 0) {
+                        takeoverForegroundNotification = false;
 
-                createNotification();
+                        newTask.setNotificationId(0);
+                    } else {
+                        newTask.setNotificationId(notificationIncremental++);
+                    }
+                    newTask.setNotificationConfig(notificationConfig);
 
-                currentTask.run();
+                    uploadTasksMap.put(newTask.uploadId, newTask);
+
+                    wakeLock.acquire();
+
+                    createNotification(newTask.uploadId);
+
+                    uploadThreadPool.execute(newTask);
+                }
             }
         }
+        return START_STICKY;
     }
 
-    void broadcastProgress(final String uploadId, final long uploadedBytes, final long totalBytes) {
+    synchronized void broadcastProgress(final String uploadId, final long uploadedBytes, final long totalBytes) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null)
+            return;
 
         long currentTime = System.currentTimeMillis();
-        if (currentTime < lastProgressNotificationTime + PROGRESS_REPORT_INTERVAL) {
+        if (currentTime < uploadTask.getLastProgressNotificationTime() + PROGRESS_REPORT_INTERVAL) {
             return;
         }
 
-        lastProgressNotificationTime = currentTime;
+        uploadTask.setLastProgressNotificationTime(currentTime);
 
-        updateNotificationProgress((int)uploadedBytes, (int)totalBytes);
+        updateNotificationProgress(uploadId, (int) uploadedBytes, (int) totalBytes);
 
         final Intent intent = new Intent(getActionBroadcast());
         intent.putExtra(UPLOAD_ID, uploadId);
@@ -152,8 +219,7 @@ public class UploadService extends IntentService {
         sendBroadcast(intent);
     }
 
-    void broadcastCompleted(final String uploadId, final int responseCode, final String responseMessage) {
-
+    synchronized void broadcastCompleted(final String uploadId, final int responseCode, final String responseMessage) {
         final String filteredMessage;
         if (responseMessage == null) {
             filteredMessage = "";
@@ -162,9 +228,9 @@ public class UploadService extends IntentService {
         }
 
         if (responseCode >= 200 && responseCode <= 299)
-            updateNotificationCompleted();
+            updateNotificationCompleted(uploadId);
         else
-            updateNotificationError();
+            updateNotificationError(uploadId);
 
         final Intent intent = new Intent(getActionBroadcast());
         intent.putExtra(UPLOAD_ID, uploadId);
@@ -172,12 +238,12 @@ public class UploadService extends IntentService {
         intent.putExtra(SERVER_RESPONSE_CODE, responseCode);
         intent.putExtra(SERVER_RESPONSE_MESSAGE, filteredMessage);
         sendBroadcast(intent);
-        wakeLock.release();
+
+        uploadTasksMap.remove(uploadId);
     }
 
-    void broadcastError(final String uploadId, final Exception exception) {
-
-        updateNotificationError();
+    synchronized void broadcastError(final String uploadId, final Exception exception) {
+        updateNotificationError(uploadId);
 
         final Intent intent = new Intent(getActionBroadcast());
         intent.setAction(getActionBroadcast());
@@ -185,73 +251,220 @@ public class UploadService extends IntentService {
         intent.putExtra(STATUS, STATUS_ERROR);
         intent.putExtra(ERROR_EXCEPTION, exception);
         sendBroadcast(intent);
-        wakeLock.release();
+
+        uploadTasksMap.remove(uploadId);
     }
 
-    private void createNotification() {
+    private void createNotification(final String uploadId) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return;
+
+        UploadNotificationConfig notificationConfig = uploadTask.getNotificationConfig();
         if (notificationConfig == null) return;
 
-        notification.setContentTitle(notificationConfig.getTitle())
-                    .setContentText(notificationConfig.getInProgressMessage())
-                    .setContentIntent(notificationConfig.getPendingIntent(this))
-                    .setSmallIcon(notificationConfig.getIconResourceID())
-                    .setProgress(100, 0, true).setOngoing(true);
+        if (getRemainingTasks() == 0) {
+            startForeground(UPLOAD_NOTIFICATION_BASE_ID, new NotificationCompat.Builder(this).build());
+        }
 
-        startForeground(UPLOAD_NOTIFICATION_ID, notification.build());
+        NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
+                .setContentTitle(notificationConfig.getTitle())
+                .setContentText(notificationConfig.getInProgressMessage())
+                .setContentIntent(notificationConfig.getPendingIntent(this))
+                .setSmallIcon(notificationConfig.getIconResourceID())
+                .setProgress(100, 0, true)
+                .setOngoing(true);
+
+        notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + uploadTask.getNotificationId(), notification.build());
     }
 
-    private void updateNotificationProgress(int uploadedBytes, int totalBytes) {
+    private void updateNotificationProgress(final String uploadId, int uploadedBytes, int totalBytes) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return;
+
+        UploadNotificationConfig notificationConfig = uploadTask.getNotificationConfig();
         if (notificationConfig == null) return;
 
-        notification.setContentTitle(notificationConfig.getTitle())
-                    .setContentText(notificationConfig.getInProgressMessage())
-                    .setContentIntent(notificationConfig.getPendingIntent(this))
-                    .setSmallIcon(notificationConfig.getIconResourceID())
-                    .setProgress(totalBytes, uploadedBytes, false)
-                    .setOngoing(true);
+        int oldNotificationId = -1;
+        if (shouldTakeoverForegroundNotification()) {
+            oldNotificationId = uploadTask.getNotificationId();
 
-        startForeground(UPLOAD_NOTIFICATION_ID, notification.build());
+            takeoverForegroundNotification = false;
+            uploadTask.setNotificationId(0);
+        }
+
+        NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
+                .setContentTitle(notificationConfig.getTitle())
+                .setContentText(notificationConfig.getInProgressMessage())
+                .setContentIntent(notificationConfig.getPendingIntent(this))
+                .setSmallIcon(notificationConfig.getIconResourceID())
+                .setProgress(totalBytes, uploadedBytes, false)
+                .setOngoing(true);
+
+        if (oldNotificationId != -1) {
+            if (tempNotificationToDisplay != null) {
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + oldNotificationId, tempNotificationToDisplay.build());
+
+                tempNotificationToDisplay = null;
+            } else {
+                notificationManager.cancel(UPLOAD_NOTIFICATION_BASE_ID + oldNotificationId);
+            }
+        }
+        notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + uploadTask.getNotificationId(), notification.build());
     }
 
-    private void updateNotificationCompleted() {
+    private void updateNotificationCompleted(final String uploadId) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return;
+
+        UploadNotificationConfig notificationConfig = uploadTask.getNotificationConfig();
         if (notificationConfig == null) return;
 
-        stopForeground(notificationConfig.isAutoClearOnSuccess());
+        if (getRemainingTasks() <= 1) {
+            stopForeground((uploadTask.getNotificationId() == 0 && notificationConfig.isAutoClearOnSuccess()) || shouldTakeoverForegroundNotification());
 
-        if (!notificationConfig.isAutoClearOnSuccess()) {
-            notification.setContentTitle(notificationConfig.getTitle())
+            takeoverForegroundNotification = false;
+
+            if (tempNotificationToDisplay != null) {
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + notificationIncremental++, tempNotificationToDisplay.build());
+
+                tempNotificationToDisplay = null;
+            }
+
+            wakeLock.release();
+        }
+
+        if (uploadTask.getNotificationId() != 0) {
+            if (!notificationConfig.isAutoClearOnSuccess()) {
+                NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
+                        .setContentTitle(notificationConfig.getTitle())
                         .setContentText(notificationConfig.getCompletedMessage())
                         .setContentIntent(notificationConfig.getPendingIntent(this))
                         .setAutoCancel(notificationConfig.isClearOnAction())
                         .setSmallIcon(notificationConfig.getIconResourceID())
                         .setProgress(0, 0, false)
                         .setOngoing(false);
-            setRingtone();
-            notificationManager.notify(UPLOAD_NOTIFICATION_ID_DONE, notification.build());
+                setRingtone(uploadId, notification);
+
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + uploadTask.getNotificationId(), notification.build());
+            } else {
+                notificationManager.cancel(UPLOAD_NOTIFICATION_BASE_ID + uploadTask.getNotificationId());
+            }
+        } else {
+            if (!notificationConfig.isAutoClearOnSuccess()) {
+                tempNotificationToDisplay = new NotificationCompat.Builder(this)
+                        .setContentTitle(notificationConfig.getTitle())
+                        .setContentText(notificationConfig.getCompletedMessage())
+                        .setContentIntent(notificationConfig.getPendingIntent(this))
+                        .setAutoCancel(notificationConfig.isClearOnAction())
+                        .setSmallIcon(notificationConfig.getIconResourceID())
+                        .setProgress(0, 0, false)
+                        .setOngoing(false);
+                setRingtone(uploadId, tempNotificationToDisplay);
+
+                if (getRemainingTasks() <= 1) {
+                    notificationManager.cancel(UPLOAD_NOTIFICATION_BASE_ID);
+
+                    notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + notificationIncremental++, tempNotificationToDisplay.build());
+
+                    tempNotificationToDisplay = null;
+                }
+            }
+
+            takeoverForegroundNotification = true;
         }
     }
 
-    private void setRingtone() {
+    private void updateNotificationError(final String uploadId) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return;
+
+        UploadNotificationConfig notificationConfig = uploadTask.getNotificationConfig();
+        if (notificationConfig == null) return;
+
+        if (shouldTakeoverForegroundNotification()) {
+            int oldNotificationId = uploadTask.getNotificationId();
+
+            takeoverForegroundNotification = false;
+            uploadTask.setNotificationId(0);
+
+            if (tempNotificationToDisplay != null) {
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + oldNotificationId, tempNotificationToDisplay.build());
+
+                tempNotificationToDisplay = null;
+            } else {
+                notificationManager.cancel(UPLOAD_NOTIFICATION_BASE_ID + oldNotificationId);
+            }
+        }
+
+        if (getRemainingTasks() <= 1) {
+            stopForeground(false);
+
+            takeoverForegroundNotification = false;
+
+            if (tempNotificationToDisplay != null) {
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + notificationIncremental++, tempNotificationToDisplay.build());
+
+                tempNotificationToDisplay = null;
+            }
+
+            wakeLock.release();
+        }
+
+        if (uploadTask.getNotificationId() != 0) {
+            NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
+                    .setContentTitle(notificationConfig.getTitle())
+                    .setContentText(notificationConfig.getErrorMessage())
+                    .setContentIntent(notificationConfig.getPendingIntent(this))
+                    .setAutoCancel(notificationConfig.isClearOnAction())
+                    .setSmallIcon(notificationConfig.getIconResourceID())
+                    .setProgress(0, 0, false)
+                    .setOngoing(false);
+            setRingtone(uploadId, notification);
+            notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + uploadTask.getNotificationId(), notification.build());
+        } else {
+            tempNotificationToDisplay = new NotificationCompat.Builder(this)
+                    .setContentTitle(notificationConfig.getTitle())
+                    .setContentText(notificationConfig.getCompletedMessage())
+                    .setContentIntent(notificationConfig.getPendingIntent(this))
+                    .setAutoCancel(notificationConfig.isClearOnAction())
+                    .setSmallIcon(notificationConfig.getIconResourceID())
+                    .setProgress(0, 0, false)
+                    .setOngoing(false);
+            setRingtone(uploadId, tempNotificationToDisplay);
+
+            if (getRemainingTasks() <= 1) {
+                notificationManager.cancel(UPLOAD_NOTIFICATION_BASE_ID);
+
+                notificationManager.notify(UPLOAD_NOTIFICATION_BASE_ID + notificationIncremental++, tempNotificationToDisplay.build());
+
+                tempNotificationToDisplay = null;
+            } else {
+                takeoverForegroundNotification = true;
+            }
+        }
+    }
+
+    private void setRingtone(final String uploadId, NotificationCompat.Builder notification) {
+        HttpUploadTask uploadTask = uploadTasksMap.get(uploadId);
+        if (uploadTask == null) return;
+
+        UploadNotificationConfig notificationConfig = uploadTask.getNotificationConfig();
+        if (notificationConfig == null) return;
 
         if(notificationConfig.isRingToneEnabled()) {
             notification.setSound(RingtoneManager.getActualDefaultRingtoneUri(this, RingtoneManager.TYPE_NOTIFICATION));
             notification.setOnlyAlertOnce(false);
         }
-
     }
 
-    private void updateNotificationError() {
-        if (notificationConfig == null) return;
+    private synchronized boolean shouldTakeoverForegroundNotification() {
+        return takeoverForegroundNotification;
+    }
 
-        stopForeground(false);
+    private synchronized long getRemainingTasks() {
+        if (uploadTasksMap == null)
+            return 0;
 
-        notification.setContentTitle(notificationConfig.getTitle())
-                    .setContentText(notificationConfig.getErrorMessage())
-                    .setContentIntent(notificationConfig.getPendingIntent(this))
-                    .setAutoCancel(notificationConfig.isClearOnAction())
-                    .setSmallIcon(notificationConfig.getIconResourceID())
-                    .setProgress(0, 0, false).setOngoing(false);
-        setRingtone();
-        notificationManager.notify(UPLOAD_NOTIFICATION_ID_DONE, notification.build());
+        return uploadTasksMap.size();
     }
 }

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadServiceBroadcastReceiver.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadServiceBroadcastReceiver.java
@@ -15,6 +15,7 @@ import android.content.IntentFilter;
  * @author alexbbb (Alex Gotev)
  * @author eliasnaur
  * @author cankov
+ * @author mabdurrahman
  *
  */
 public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
@@ -28,10 +29,6 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
                 final String uploadId = intent.getStringExtra(UploadService.UPLOAD_ID);
 
                 switch (status) {
-                    case UploadService.STATUS_CANCELLED:
-                        onCancelled(uploadId);
-                        break;
-
                     case UploadService.STATUS_ERROR:
                         final Exception exception = (Exception) intent
                                 .getSerializableExtra(UploadService.ERROR_EXCEPTION);
@@ -54,6 +51,10 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
 
                         break;
 
+                    case UploadService.STATUS_CANCELLED:
+                        onCancelled(uploadId);
+                        break;
+
                     default:
                         break;
                 }
@@ -64,7 +65,10 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
 
     /**
      * Register this upload receiver.
-     * It's recommended to register the receiver in Activity's onResume method.
+     * If you use this receiver in an {@link android.app.Activity}, you have to call this method inside
+     * {@link android.app.Activity#onResume()}, after {@code super.onResume();}.
+     * If you use it in a {@link android.app.Service}, you have to
+     * call this method inside {@link android.app.Service#onCreate()}, after {@code super.onCreate();}.
      *
      * @param context context in which to register this receiver
      */
@@ -76,7 +80,10 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
 
     /**
      * Unregister this upload receiver.
-     * It's recommended to unregister the receiver in Activity's onPause method.
+     * If you use this receiver in an {@link android.app.Activity}, you have to call this method inside
+     * {@link android.app.Activity#onPause()}, after {@code super.onPause();}.
+     * If you use it in a {@link android.app.Service}, you have to
+     * call this method inside {@link android.app.Service#onDestroy()}.
      *
      * @param context context in which to unregister this receiver
      */

--- a/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadServiceBroadcastReceiver.java
+++ b/uploadservice/src/main/java/com/alexbbb/uploadservice/UploadServiceBroadcastReceiver.java
@@ -28,6 +28,10 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
                 final String uploadId = intent.getStringExtra(UploadService.UPLOAD_ID);
 
                 switch (status) {
+                    case UploadService.STATUS_CANCELLED:
+                        onCancelled(uploadId);
+                        break;
+
                     case UploadService.STATUS_ERROR:
                         final Exception exception = (Exception) intent
                                 .getSerializableExtra(UploadService.ERROR_EXCEPTION);
@@ -120,5 +124,13 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
      */
     public void onCompleted(final String uploadId, final int serverResponseCode,
                             final String serverResponseMessage) {
+    }
+
+    /**
+     * Called when the upload is cancelled. Override this method to add your own logic.
+     *
+     * @param uploadId unique ID of the upload request
+     */
+    public void onCancelled(final String uploadId) {
     }
 }


### PR DESCRIPTION
* added parallel multiple upload support controlled by ThreadPoolExecuter, default pool size equals number of available cores, and can be set by changing UploadService.UPLOAD_POOL_SIZE property
* modified the demo app according to the parallel multiple upload support
* enhanced upload task cancellation capability based on the new parallel multiple upload support, added new onCancelled() callback to properly handle actions on cancellation
* implementing the newly introduced onCancelled() callback on the demo application

